### PR TITLE
Move node deletion to oci

### DIFF
--- a/pkg/node/spec.go
+++ b/pkg/node/spec.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/medyagh/kic/pkg/config/cri"
+	"github.com/medyagh/kic/pkg/oci"
 	"github.com/medyagh/kic/pkg/runner"
 	"github.com/pkg/errors"
 )
@@ -75,12 +76,7 @@ func (d *Spec) Stop() error {
 }
 
 func (d *Spec) Delete() error {
-	cmd := runner.Command("docker", "rm", "-f", "-v", d.Name)
-	_, err := runner.CombinedOutputLines(cmd)
-	if err != nil {
-		return errors.Wrapf(err, "deleting node")
-	}
-	return nil
+	return oci.Delete(d.Name)
 }
 
 // ListNodes lists all the nodes (containers) created by kic on the system

--- a/pkg/oci/delete.go
+++ b/pkg/oci/delete.go
@@ -1,0 +1,19 @@
+package oci
+
+import (
+	"github.com/medyagh/kic/pkg/runner"
+
+	"github.com/pkg/errors"
+)
+
+// Delete removes a container
+func Delete(ociID string) error {
+	// TODO: force remove should be an option
+	cmd := runner.Command(DefaultOCI, "rm", "-f", "-v", ociID)
+	_, err := runner.CombinedOutputLines(cmd)
+	if err != nil {
+		return errors.Wrapf(err, "error deleting node %s", ociID)
+	}
+
+	return nil
+}


### PR DESCRIPTION
moving deleting to oci because once we start to integrate podman, deletion will depend on the container  runtime.

@medyagh let me know what you think, I want to do the same for `stop`