### PR TITLE
Refactor Node API

### DIFF
--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -13,7 +13,7 @@ make out/e2e
 
 # clean up the previous runs (if any)
 lsof -ti tcp:8080 | xargs kill || true
-./out/e2e -remove -profile m5
+./out/e2e -remove -profile m5 || true
 
 # start a cluster
 echo "Starting a cluster with 2 cpu and 2 GB ram" && ./out/e2e -start -profile m5 -cpu 2 -memory 2000m

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -13,7 +13,7 @@ make out/e2e
 
 # clean up the previous runs (if any)
 lsof -ti tcp:8080 | xargs kill || true
-./out/e2e -delete -profile m5
+./out/e2e -remove -profile m5
 
 # start a cluster
 echo "Starting a cluster with 2 cpu and 2 GB ram" && ./out/e2e -start -profile m5 -cpu 2 -memory 2000m
@@ -68,11 +68,11 @@ echo "Checking if image is loaded" && docker exec cluster2-control-plane ctr -n 
 ## copy file from user machine to cluster
 touch copy-test.txt
 echo "copy test" > copy-test.txt
-echo "Copying file from user machine to cluster" && ./out/e2e -profile cluster2 -cp=true -src=copy-test.txt -dest=/etc/copy-test.txt
+echo "Copying file from user machine to cluster" && ./out/e2e -profile cluster2 -cp -src=copy-test.txt -dest=/etc/copy-test.txt
 echo "Checking if file was copied" && docker exec cluster2-control-plane cat /etc/copy-test.txt | grep "copy test"
 
 ## remove file from cluster
-echo "Removing file from cluster" && ./out/e2e -profile cluster2 -rm=true -src=/etc/copy-test.txt
+echo "Removing file from cluster" && ./out/e2e -profile cluster2 -rm-file -src=/etc/copy-test.txt
 echo "Checking if file was removed" && docker exec cluster2-control-plane test ! -f /etc/copy-test.txt
 
 ## pause a node
@@ -83,7 +83,7 @@ echo "Checking if node was paused" && docker inspect --format '{{.State.Status}}
 echo "Stopping a node" && ./out/e2e -stop -profile cluster2
 echo "Checking if node was stopped" && docker inspect --format '{{.State.Status}}' cluster2-control-plane  | grep exited
 
-# delete our cluster in the end
-./out/e2e -delete -profile cluster2
+# remove our cluster in the end
+./out/e2e -remove -profile cluster2
 
 lsof -ti tcp:8080 | xargs kill || true

--- a/example/single_node/README.md
+++ b/example/single_node/README.md
@@ -6,7 +6,5 @@
 	kubectl expose deployment hello-minikube --type=NodePort
  	kubectl port-forward service/hello-minikube 8080
 	curl http://localhost:8080/
-    ./single_node -delete -profile m5
-
-
+    ./single_node -remove -profile m5
 ```

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -74,7 +74,7 @@ func (n *Node) IP() (ipv4 string, ipv6 string, err error) {
 	return ips[0], ips[1], nil
 }
 
-// LoadImageArchive loads an image form archive into node
+// LoadImageArchive loads an image from archive into the node
 func (n *Node) LoadImageArchive(image io.Reader) error {
 	cmd := n.Command(
 		"ctr", "--namespace=k8s.io", "images", "import", "-",
@@ -86,7 +86,7 @@ func (n *Node) LoadImageArchive(image io.Reader) error {
 	return nil
 }
 
-// Copy copies a local asset into a node.
+// Copy copies a local asset into the node
 func (n *Node) Copy(asset assets.CopyAsset) error {
 	if err := oci.Copy(n.name, asset); err != nil {
 		return errors.Wrap(err, "failed to copy file/folder")
@@ -99,13 +99,19 @@ func (n *Node) Copy(asset assets.CopyAsset) error {
 	return nil
 }
 
-// Remove removes a file from node
-func (n *Node) Remove(source string) error {
-	cmd := n.Command("rm", source)
-	if err := cmd.Run(); err != nil {
-		return errors.Wrap(err, "failed to remove file")
-	}
-	return nil
+// Pause pauses all process in the node
+func (n *Node) Pause() error {
+	return oci.Pause(n.name)
+}
+
+// Stop stops the node
+func (n *Node) Stop() error {
+	return oci.Stop(n.name)
+}
+
+// Remove removes the node
+func (n *Node) Remove() error {
+	return oci.Remove(n.name)
 }
 
 // Command returns a new runner.Cmd that will run on the node

--- a/pkg/node/spec.go
+++ b/pkg/node/spec.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/medyagh/kic/pkg/config/cri"
-	"github.com/medyagh/kic/pkg/oci"
 	"github.com/medyagh/kic/pkg/runner"
 	"github.com/pkg/errors"
 )
@@ -64,20 +63,6 @@ func (d *Spec) Create(cmder runner.Cmder) (node *Node, err error) {
 	default:
 		return nil, fmt.Errorf("unknown node role: %s", d.Role)
 	}
-}
-
-// Pause pauses all process in a node
-func (d *Spec) Pause() error {
-	return oci.Pause(d.Name)
-}
-
-// Stop stops a node
-func (d *Spec) Stop() error {
-	return oci.Stop(d.Name)
-}
-
-func (d *Spec) Delete() error {
-	return oci.Delete(d.Name)
 }
 
 // ListNodes lists all the nodes (containers) created by kic on the system

--- a/pkg/oci/remove.go
+++ b/pkg/oci/remove.go
@@ -6,13 +6,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Delete removes a container
-func Delete(ociID string) error {
+// Remove removes a container
+func Remove(ociID string) error {
 	// TODO: force remove should be an option
 	cmd := runner.Command(DefaultOCI, "rm", "-f", "-v", ociID)
 	_, err := runner.CombinedOutputLines(cmd)
 	if err != nil {
-		return errors.Wrapf(err, "error deleting node %s", ociID)
+		return errors.Wrapf(err, "error removing node %s", ociID)
 	}
 
 	return nil


### PR DESCRIPTION
Starting a refactoring towards a better API: https://github.com/medyagh/kic/issues/32

- move `Pause`, `Stop`, and `Delete` from Spec to Node
- rename `oci.Delete` to `oci.Remove` to reflect the docker/podman command used to remove the container
- extract removing file from `Node`, removing a file is a command called inside a command, no need to have a specific method for it, calling `n.Command` reflects it better